### PR TITLE
Changes parser implementation to follow HTTP standards

### DIFF
--- a/services/api/body_parsers/removal.py
+++ b/services/api/body_parsers/removal.py
@@ -8,8 +8,8 @@ class RemovalParser:
     def __init__(self):
         parser = RequestParser()
         fields = [
-            {'name': 'petshop_username', 'type': str, 'location': 'form', 'required': True},
-            {'name': 'service_id', 'type': str, 'location': 'form', 'required': True}
+            {'name': 'petshop_username', 'type': str, 'location': 'args', 'required': True},
+            {'name': 'service_id', 'type': str, 'location': 'args', 'required': True}
         ]
         for field in fields:
             parser.add_argument(**field)

--- a/tests/api/body_parsers/removal.py
+++ b/tests/api/body_parsers/removal.py
@@ -26,13 +26,13 @@ class RemovalParserTestCase(unittest.TestCase):
             call(
                 name='petshop_username',
                 type=str,
-                location='form',
+                location='args',
                 required=True
             ),
             call(
                 name='service_id',
                 type=str,
-                location='form',
+                location='args',
                 required=True
             )
         ]


### PR DESCRIPTION
The DELETE method does not allow requests with bodies on them, so the parsing was changed to move the args location

Signed-off-by: erossi-impacta <eric.rossi@aluno.faculdadeimpacta.com.br>